### PR TITLE
Fix version conflict between babel-loader and babel-core

### DIFF
--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -35,7 +35,7 @@ kotlinFrontend {
         devDependency("css-loader")
         devDependency("style-loader")
         devDependency("babel-loader")
-        devDependency("babel-core")
+        devDependency("@babel/core")
         devDependency("karma")
     }
 


### PR DESCRIPTION
babel-loader@8.0.2 requires @babel/core@^7.0.0 which was renamed to @babel/core from babel-core